### PR TITLE
Fix chain import and revalidate API bug

### DIFF
--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
 
 export async function POST(req: NextRequest) {
   const secret = req.nextUrl.searchParams.get("secret");
@@ -9,7 +10,7 @@ export async function POST(req: NextRequest) {
   const { path } = await req.json();          // es.: "/blog/welcome"
   try {
     // Next.js 15 revalidate tag-free:
-    await res.revalidate(path);
+    await revalidatePath(path);
     return NextResponse.json({ revalidated: true, path });
   } catch (err) {
     return NextResponse.json({ error: (err as Error).message }, { status: 500 });

--- a/src/components/TokenBalance.tsx
+++ b/src/components/TokenBalance.tsx
@@ -2,7 +2,7 @@
 'use client';
 
 import { useAccount, useContractRead } from 'wagmi';
-import { polygonMumbai }               from 'wagmi/chains';
+import { polygonAmoy }                 from 'wagmi/chains';
 import ABI                              from '@/lib/abi/PolygonAmoyToken.json'; // ok anche se il nome del file resta
 
 const TOKEN_ADDRESS = '0xAbCd...'; // <-- metti l’indirizzo corretto


### PR DESCRIPTION
## Summary
- fix incorrect chain import in `TokenBalance`
- fix `revalidate` API route to use `revalidatePath`

## Testing
- `npm exec tsc -- -p tsconfig.json` *(fails: Cannot find module wagmi, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684310f26efc832c8bf0dc7e50857afc