### PR TITLE
Fix revalidate call

### DIFF
--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
 
 export async function POST(req: NextRequest) {
   const secret = req.nextUrl.searchParams.get("secret");
@@ -9,7 +10,7 @@ export async function POST(req: NextRequest) {
   const { path } = await req.json();          // es.: "/blog/welcome"
   try {
     // Next.js 15 revalidate tag-free:
-    await res.revalidate(path);
+    await revalidatePath(path);
     return NextResponse.json({ revalidated: true, path });
   } catch (err) {
     return NextResponse.json({ error: (err as Error).message }, { status: 500 });


### PR DESCRIPTION
## Summary
- fix the revalidate route to use `revalidatePath`

## Testing
- `npm run lint` *(fails: Invalid options)*

------
https://chatgpt.com/codex/tasks/task_e_6843238ee8c0832c968f8858af9e8418