### PR TITLE
Wrap layout with AppProviders

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,13 +1,16 @@
 // src/app/layout.tsx
 import { ReactNode } from "react";
 import Layout from "@/components/Layout";
+import AppProviders from "@/components/AppProviders";
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body>
         {/* wrapper globale con Header + Footer */}
-        <Layout>{children}</Layout>
+        <AppProviders>
+          <Layout>{children}</Layout>
+        </AppProviders>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- import `AppProviders`
- wrap `<Layout>` with `<AppProviders>` so providers are applied globally

## Testing
- `npm run lint` *(fails: Invalid Options)*
- `npm run build` *(fails: Next.js build not completed)*

------
https://chatgpt.com/codex/tasks/task_e_684329295210832c9b62185508146129