### PR TITLE
Add React Query provider

### DIFF
--- a/src/components/AppProviders.tsx
+++ b/src/components/AppProviders.tsx
@@ -3,7 +3,10 @@
 import { ReactNode } from "react";
 import { WagmiProvider } from "wagmi";
 import { RainbowKitProvider, getDefaultConfig } from "@rainbow-me/rainbowkit";
-import "@rainbow-me/rainbowkit/styles.css";          // <-- css globale RainbowKit
+import "@rainbow-me/rainbowkit/styles.css"; // <-- css globale RainbowKit
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const queryClient = new QueryClient();
 
 // chain che stai usando
 import { polygonAmoy } from "wagmi/chains";
@@ -21,9 +24,11 @@ export const wagmiConfig = getDefaultConfig({
 export default function AppProviders({ children }: { children: ReactNode }) {
   return (
     <WagmiProvider config={wagmiConfig}>
-      <RainbowKitProvider chains={[polygonAmoy]}>
-        {children}
-      </RainbowKitProvider>
+      <QueryClientProvider client={queryClient}>
+        <RainbowKitProvider chains={[polygonAmoy]}>
+          {children}
+        </RainbowKitProvider>
+      </QueryClientProvider>
     </WagmiProvider>
   );
 }


### PR DESCRIPTION
## Summary
- add React Query imports
- create a `QueryClient` singleton
- wrap RainbowKit with `QueryClientProvider`

## Testing
- `pnpm run build` *(fails: Failed to collect configuration for /about)*

------
https://chatgpt.com/codex/tasks/task_e_68432ad93be4832caf532409cd4e769a