### PR TITLE
fix: wrap providers

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,13 +1,16 @@
 // src/app/layout.tsx
 import { ReactNode } from "react";
 import Layout from "@/components/Layout";
+import AppProviders from "@/components/AppProviders";
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body>
         {/* wrapper globale con Header + Footer */}
-        <Layout>{children}</Layout>
+        <AppProviders>
+          <Layout>{children}</Layout>
+        </AppProviders>
       </body>
     </html>
   );

--- a/src/components/AppProviders.tsx
+++ b/src/components/AppProviders.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { ReactNode } from "react";
+import { ReactNode, useState } from "react";
 import { WagmiProvider } from "wagmi";
 import { RainbowKitProvider, getDefaultConfig } from "@rainbow-me/rainbowkit";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import "@rainbow-me/rainbowkit/styles.css";          // <-- css globale RainbowKit
 
 // chain che stai usando
@@ -19,11 +20,15 @@ export const wagmiConfig = getDefaultConfig({
 });
 
 export default function AppProviders({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(() => new QueryClient());
+
   return (
     <WagmiProvider config={wagmiConfig}>
-      <RainbowKitProvider chains={[polygonAmoy]}>
-        {children}
-      </RainbowKitProvider>
+      <QueryClientProvider client={queryClient}>
+        <RainbowKitProvider chains={[polygonAmoy]}>
+          {children}
+        </RainbowKitProvider>
+      </QueryClientProvider>
     </WagmiProvider>
   );
 }


### PR DESCRIPTION
## Summary
- wrap app with AppProviders that configures Wagmi, QueryClient, and RainbowKit

## Testing
- `pnpm run build` *(fails: Failed to collect page data for /blog/[slug])*

------
https://chatgpt.com/codex/tasks/task_e_68433a82d36c832c952cede29b2648c3