### PR TITLE
feat: switch to Polygon Amoy

### DIFF
--- a/src/components/WagmiProviders.tsx
+++ b/src/components/WagmiProviders.tsx
@@ -2,14 +2,15 @@
 
 import { WagmiConfig }            from 'wagmi';
 import { RainbowKitProvider }     from '@rainbow-me/rainbowkit';
-import { wagmiConfig, chains }    from '@/lib/wagmi';
+import { wagmiConfig }            from '@/lib/wagmi';
+import { polygonAmoy }            from 'wagmi/chains';
 
 export default function WagmiProviders({
   children,
 }: { children: React.ReactNode }) {
   return (
     <WagmiConfig config={wagmiConfig}>
-      <RainbowKitProvider chains={chains} modalSize="compact">
+      <RainbowKitProvider chains={[polygonAmoy]} modalSize="compact">
         {children}
       </RainbowKitProvider>
     </WagmiConfig>


### PR DESCRIPTION
## Summary
- ensure WagmiProviders uses the Polygon Amoy chain

## Testing
- `pnpm install`
- `pnpm test`
- `pnpm run build` *(fails: Next.js build does not finish in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_6844adc60fac832c94946ec60e4834b1