### PR TITLE
Refine public pages and wallet button

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,18 +1,10 @@
-import { notFound } from "next/navigation";
-import { documentToReactComponents } from "@contentful/rich-text-react-renderer";
-import { getPage } from "@/lib/contentful";
+export const metadata = { title: 'About | Carbosia' };
 
-export default async function AboutPage() {
-  const data = await getPage("about");
-  if (!data) return notFound();
-
+export default function AboutPage() {
   return (
-    <main className="mx-auto max-w-3xl px-6 py-16">
-      <h1 className="text-4xl font-bold mb-8">{data.title}</h1>
-
-      <article className="prose prose-green">
-        {documentToReactComponents(data.body as any)}
-      </article>
-    </main>
+    <section className="space-y-6">
+      <h1 className="text-4xl font-bold">Chi siamo</h1>
+      <p>Contenuti in arrivo.</p>
+    </section>
   );
 }

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,29 +1,10 @@
-import Link from "next/link";
-import { format } from "date-fns";
-import { it } from "date-fns/locale";
-import { getBlogPosts } from "@/lib/contentful";
+export const metadata = { title: 'Blog | Carbosia' };
 
-export const metadata = { title: "Blog | Carbosia" };
-
-export default async function BlogPage() {
-  const posts = await getBlogPosts();
-
+export default function BlogPage() {
   return (
-    <section className="space-y-8">
+    <section className="space-y-6">
       <h1 className="text-4xl font-bold">Blog</h1>
-
-      {posts.map((p: any) => (
-        <article key={p.sys.id} className="border-b pb-6">
-          <h2 className="text-2xl font-semibold">
-            <Link href={`/blog/${p.fields.slug}`} className="hover:underline">
-              {p.fields.title}
-            </Link>
-          </h2>
-          <p className="text-sm text-gray-500">
-            {format(new Date(p.fields.date), "d MMMM yyyy", { locale: it })}
-          </p>
-        </article>
-      ))}
+      <p>Nessun articolo disponibile.</p>
     </section>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,25 +1,14 @@
-import { getPage } from '@/lib/contentful';
-import { documentToReactComponents } from '@contentful/rich-text-react-renderer';
-
-export default async function HomePage() {
-  // recupera l’entry con slug “home”
-  const data = await getPage('home');
-
-  if (!data) {
-    return (
-      <main className="p-10 text-center">
-        Contenuto non trovato.
-      </main>
-    );
-  }
-
+export default function HomePage() {
   return (
-    <main className="mx-auto max-w-4xl px-6 py-16">
-      <h1 className="mb-8 text-4xl font-bold">{data.title}</h1>
-
-      <article className="prose prose-green">
-        {documentToReactComponents(data.body as any)}
-      </article>
-    </main>
+    <section className="mx-auto flex max-w-5xl flex-col items-center gap-6 py-20 text-center">
+      <h1 className="text-5xl font-bold">Carbosia</h1>
+      <p className="text-xl text-gray-600">Il marketplace per la compensazione di CO₂</p>
+      <a
+        href="/projects"
+        className="rounded-xl bg-brand px-6 py-3 font-semibold text-white hover:bg-brand-dark"
+      >
+        Entra in Carbosia
+      </a>
+    </section>
   );
 }

--- a/src/components/WalletButton.tsx
+++ b/src/components/WalletButton.tsx
@@ -1,7 +1,16 @@
 'use client';
 
+import { useAccount } from 'wagmi';
 import { ConnectButton } from '@rainbow-me/rainbowkit';
 
 export default function WalletButton() {
-  return <ConnectButton />;
+  const { address, isConnected } = useAccount();
+
+  return isConnected ? (
+    <button className="rounded-xl bg-brand px-4 py-2 text-white">
+      {address ? `${address.slice(0, 6)}…${address.slice(-4)}` : 'Connesso'}
+    </button>
+  ) : (
+    <ConnectButton showBalance={false} chainStatus="icon" />
+  );
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -22,8 +22,9 @@ const config: Config = {
     extend: {
       colors: {
         brand: {
-          DEFAULT: '#17B47B',
-          dark: '#0E8C60',
+          DEFAULT: '#2db23c',
+          dark: '#21952f',
+          light: '#e6f6e9',
         },
       },
       fontFamily: {


### PR DESCRIPTION
## Summary
- update color palette with brand colors
- show address in `WalletButton`
- simplify landing page
- add placeholder /about and /blog

## Testing
- `pnpm lint` *(fails: Invalid Options)*
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68453bb8146c832ca21f2595939eeee9