### PR TITLE
WalletButton → testo Connesso

### DIFF
--- a/src/components/WalletButton.tsx
+++ b/src/components/WalletButton.tsx
@@ -1,14 +1,16 @@
 'use client';
 
+import React from 'react';
+
 import { useAccount } from 'wagmi';
 import { ConnectButton } from '@rainbow-me/rainbowkit';
 
 export default function WalletButton() {
-  const { address, isConnected } = useAccount();
+  const { isConnected } = useAccount();
 
   return isConnected ? (
     <button className="rounded-xl bg-brand px-4 py-2 text-white">
-      {address ? `${address.slice(0, 6)}…${address.slice(-4)}` : 'Connesso'}
+      Connesso
     </button>
   ) : (
     <ConnectButton showBalance={false} chainStatus="icon" />

--- a/src/walletButton.test.tsx
+++ b/src/walletButton.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import WalletButton from './components/WalletButton';
+import * as wagmi from 'wagmi';
+
+vi.mock('wagmi', async () => {
+  const actual = await vi.importActual<typeof wagmi>('wagmi');
+  return { ...actual, useAccount: vi.fn() };
+});
+
+vi.mock('@rainbow-me/rainbowkit', () => ({ ConnectButton: () => <div>Connect Wallet</div> }));
+
+describe('WalletButton', () => {
+  it('shows "Connesso" when connected', () => {
+    (wagmi.useAccount as any).mockReturnValue({ isConnected: true });
+    render(<WalletButton />);
+    expect(screen.getByRole('button').textContent).toBe('Connesso');
+  });
+
+  it('shows connect button when not connected', () => {
+    (wagmi.useAccount as any).mockReturnValue({ isConnected: false });
+    render(<WalletButton />);
+    expect(screen.getByText('Connect Wallet')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- update WalletButton to show "Connesso" instead of address
- add unit test for WalletButton

## Testing
- `pnpm test`
- `pnpm run build` *(fails: Next.js build hung)*

------
https://chatgpt.com/codex/tasks/task_e_684549a20364832cb9f538ddf698202a