### PR TITLE
WalletButton – click = disconnect

### DIFF
--- a/src/components/WalletButton.tsx
+++ b/src/components/WalletButton.tsx
@@ -2,14 +2,18 @@
 
 import React from 'react';
 
-import { useAccount } from 'wagmi';
+import { useAccount, useDisconnect } from 'wagmi';
 import { ConnectButton } from '@rainbow-me/rainbowkit';
 
 export default function WalletButton() {
   const { isConnected } = useAccount();
+  const { disconnect } = useDisconnect();
 
   return isConnected ? (
-    <button className="rounded-xl bg-brand px-4 py-2 text-white">
+    <button
+      className="rounded-xl bg-brand px-4 py-2 text-white"
+      onClick={() => disconnect()}
+    >
       Connesso
     </button>
   ) : (

--- a/src/walletButton.test.tsx
+++ b/src/walletButton.test.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import WalletButton from './components/WalletButton';
 import * as wagmi from 'wagmi';
 
 vi.mock('wagmi', async () => {
   const actual = await vi.importActual<typeof wagmi>('wagmi');
-  return { ...actual, useAccount: vi.fn() };
+  return { ...actual, useAccount: vi.fn(), useDisconnect: vi.fn() };
 });
 
 vi.mock('@rainbow-me/rainbowkit', () => ({ ConnectButton: () => <div>Connect Wallet</div> }));
@@ -13,6 +13,7 @@ vi.mock('@rainbow-me/rainbowkit', () => ({ ConnectButton: () => <div>Connect Wal
 describe('WalletButton', () => {
   it('shows "Connesso" when connected', () => {
     (wagmi.useAccount as any).mockReturnValue({ isConnected: true });
+    (wagmi.useDisconnect as any).mockReturnValue({ disconnect: vi.fn() });
     render(<WalletButton />);
     expect(screen.getByRole('button').textContent).toBe('Connesso');
   });
@@ -21,5 +22,14 @@ describe('WalletButton', () => {
     (wagmi.useAccount as any).mockReturnValue({ isConnected: false });
     render(<WalletButton />);
     expect(screen.getByText('Connect Wallet')).toBeTruthy();
+  });
+
+  it('disconnects on click', () => {
+    const disconnect = vi.fn();
+    (wagmi.useAccount as any).mockReturnValue({ isConnected: true });
+    (wagmi.useDisconnect as any).mockReturnValue({ disconnect });
+    render(<WalletButton />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(disconnect).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- add disconnect to wallet button using `useDisconnect`
- extend wallet button tests to cover disconnect behavior

## Testing
- `pnpm test`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_68454fdb5dc4832cb10ffa92b3b1c1b7