### PR TITLE
Fix pnpm setup in demo deploy workflow

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -24,10 +24,10 @@ jobs:
         with:
           node-version: 20
           cache: pnpm
-      - name: Install pnpm
-        run: |
-          corepack enable
-          corepack prepare pnpm@9 --activate
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 9
+          run_install: false
       - name: Sanity check pnpm
         run: pnpm --version
       - run: pnpm install


### PR DESCRIPTION
## Summary
- use `pnpm/action-setup` so pnpm is available in CI

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684888043bcc832c9027cf85e614cbcf